### PR TITLE
Seek updates

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -2,7 +2,7 @@
 
 /// Represents an open directory
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct Handle(u8);
 
 impl Handle {

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,5 +1,21 @@
 //! Directory related types
 
+// ============================================================================
+// Imports
+// ============================================================================
+
+// None
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// None
+
+// ============================================================================
+// Types
+// ============================================================================
+
 /// Represents an open directory
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -8,12 +24,9 @@ pub struct Handle(u8);
 impl Handle {
     /// Construct a new `Handle` from an integer.
     ///
-    /// Only the OS should call this.
-    ///
-    /// # Safety
-    ///
-    /// The integer given must be a valid index for an open Directory.
-    #[cfg(feature = "os")]
+    /// Only the OS should call this - applications should not be constructing
+    /// their own dir handles! But if you do, you probably can't harm anything
+    /// and it's no worse that C just using `int`.
     pub const fn new(value: u8) -> Handle {
         Handle(value)
     }
@@ -30,8 +43,28 @@ impl Handle {
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Entry {
-    /// The name and extension of the file
+    /// The name and extension of the file.
+    ///
+    /// The name and extension are separated by a single '.'.
+    ///
+    /// The filename will be in ASCII. Unicode filenames are not supported.
     pub name: [u8; crate::MAX_FILENAME_LEN],
-    /// File properties
+    /// The properties for the file/directory this entry represents.
     pub properties: crate::file::Stat,
 }
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+// None
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+// None
+
+// ============================================================================
+// End of File
+// ============================================================================

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,172 +1,20 @@
 //! File related types
 
+// ============================================================================
+// Imports
+// ============================================================================
+
 use bitflags::bitflags;
-use neotron_ffi::FfiString;
 
-/// Represents a (borrowed) path to file.
-///
-/// Neotron OS uses the following format for file paths:
-///
-/// `<disk>:/[<directory>/]+<filename>.<extension>`
-///
-/// Unlike on MS-DOS, the `disk` specifier portion is not limited to a single
-/// ASCII letter and can be any UTF-8 string that does not contain `:` or `/`.
-///
-/// Paths are a sub-set of UTF-8 strings in this API, but be aware that not all
-/// filesystems support all Unicode characters. In particular FAT16 and FAT32
-/// volumes are likely to be limited to only `A-Z`, `a-z`, `0-9` and
-/// `$%-_@~\`!(){}^#&`. This API will expressly disallow UTF-8 codepoints below
-/// 32 (i.e. C0 control characters) to avoid confusion.
-///
-/// Paths are case-preserving but may not be case-sensitive. Paths may contain
-/// spaces, if your filesystem supports it.
-///  
-/// Here are some examples of valid paths:
-///
-/// ```text
-/// Documents/2023/June/Sales in €.xls - relative to the Current Directory
-/// HD0:/MYDOCU~1/SALES.TXT - a file on drive HD0
-/// SD0:/MYDOCU~1/ - a directory on drive SD0
-/// SD0:/BOOTLDR - a file on drive SD0, with no file extension
-/// CON$: - a special device file
-/// SER0$:/bps=9600/parity=N/timeout=100: - a special device file with parameters
-/// ```
-#[repr(C)]
-pub struct Path<'a>(FfiString<'a>);
+// ============================================================================
+// Constants
+// ============================================================================
 
-impl<'a> Path<'a> {
-    /// The character that separates one directory name from another directory name.
-    pub const PATH_SEP: char = '/';
+// None
 
-    /// The character that separates drive specifiers from directories.
-    pub const DRIVE_SEP: char = ':';
-
-    /// Create a path from a string.
-    ///
-    /// If the given string is not a valid path, an `Err` is returned.
-    pub fn new(path_str: &'a str) -> Result<Path<'a>, crate::Error> {
-        // No empty paths in drive specifier
-        if path_str.is_empty() {
-            return Err(crate::Error::InvalidPath);
-        }
-
-        if let Some((drive_specifier, directory_path)) = path_str.split_once(Self::DRIVE_SEP) {
-            if drive_specifier.contains(Self::PATH_SEP) {
-                // No slashes in drive specifier
-                return Err(crate::Error::InvalidPath);
-            }
-            if directory_path.contains(Self::DRIVE_SEP) {
-                // No colons in directory path
-                return Err(crate::Error::InvalidPath);
-            }
-            if !directory_path.is_empty() && !directory_path.starts_with(Self::PATH_SEP) {
-                // No relative paths if drive is specified. An empty path is OK (it means "/")
-                return Err(crate::Error::InvalidPath);
-            }
-        } else if path_str.starts_with(Self::PATH_SEP) {
-            // No absolute paths if drive is not specified
-            return Err(crate::Error::InvalidPath);
-        }
-        for ch in path_str.chars() {
-            if ch.is_control() {
-                // No control characters allowed
-                return Err(crate::Error::InvalidPath);
-            }
-        }
-        Ok(Path(FfiString::new(path_str)))
-    }
-
-    /// Is this an absolute path?
-    ///
-    /// Absolute paths have drive specifiers. Relative paths do not.
-    pub fn is_absolute_path(&self) -> bool {
-        self.drive_specifier().is_some()
-    }
-
-    /// Get the drive specifier for this path.
-    ///
-    /// * A path like `DS0:/FOO/BAR.TXT` has a drive specifier of `DS0`.
-    /// * A path like `BAR.TXT` has no drive specifier.
-    pub fn drive_specifier(&self) -> Option<&str> {
-        let path_str = self.0.as_str();
-        if let Some((drive_specifier, _directory_path)) = path_str.split_once(Self::DRIVE_SEP) {
-            Some(drive_specifier)
-        } else {
-            None
-        }
-    }
-
-    /// Get the drive path portion.
-    ///
-    /// That is, everything after the directory specifier.
-    pub fn drive_path(&self) -> Option<&str> {
-        let path_str = self.0.as_str();
-        if let Some((_drive_specifier, drive_path)) = path_str.split_once(Self::DRIVE_SEP) {
-            if drive_path.is_empty() {
-                Some("/")
-            } else {
-                Some(drive_path)
-            }
-        } else {
-            Some(path_str)
-        }
-    }
-
-    /// Get the directory portion of this path.
-    ///
-    /// * A path like `DS0:/FOO/BAR.TXT` has a directory portion of `/FOO`.
-    /// * A path like `DS0:/FOO/BAR/` has a directory portion of `/FOO/BAR`.
-    /// * A path like `BAR.TXT` has no directory portion.
-    pub fn directory(&self) -> Option<&str> {
-        let Some(drive_path) = self.drive_path() else {
-            return None;
-        };
-        if let Some((directory, _filename)) = drive_path.rsplit_once(Self::PATH_SEP) {
-            if directory.is_empty() {
-                None
-            } else {
-                Some(directory)
-            }
-        } else {
-            Some(drive_path)
-        }
-    }
-
-    /// Get the filename portion of this path. This filename will include the file extension, if any.
-    ///
-    /// * A path like `DS0:/FOO/BAR.TXT` has a filename portion of `/BAR.TXT`.
-    /// * A path like `DS0:/FOO` has a filename portion of `/FOO`.
-    /// * A path like `DS0:/FOO/` has no filename portion (so it's important directories have a trailing `/`)
-    pub fn filename(&self) -> Option<&str> {
-        let Some(drive_path) = self.drive_path() else {
-            return None;
-        };
-        if let Some((_directory, filename)) = drive_path.rsplit_once(Self::PATH_SEP) {
-            if filename.is_empty() {
-                None
-            } else {
-                Some(filename)
-            }
-        } else {
-            Some(drive_path)
-        }
-    }
-
-    /// Get the filename extension portion of this path.
-    ///
-    /// A path like `DS0:/FOO/BAR.TXT` has a filename extension portion of `TXT`.
-    /// A path like `DS0:/FOO/BAR` has no filename extension portion.
-    pub fn extension(&self) -> Option<&str> {
-        let Some(filename) = self.filename() else {
-            return None;
-        };
-        if let Some((_basename, extension)) = filename.rsplit_once('.') {
-            Some(extension)
-        } else {
-            None
-        }
-    }
-}
+// ============================================================================
+// Types
+// ============================================================================
 
 /// Represents an open file
 #[repr(C)]
@@ -285,55 +133,18 @@ pub struct Time {
     pub seconds: u8,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// ============================================================================
+// Functions
+// ============================================================================
 
-    #[test]
-    fn full_path() {
-        let path_str = "HD0:/DOCUMENTS/JUNE/SALES.TXT";
-        let path = Path::new(path_str).unwrap();
-        assert!(path.is_absolute_path());
-        assert_eq!(path.drive_specifier(), Some("HD0"));
-        assert_eq!(path.drive_path(), Some("/DOCUMENTS/JUNE/SALES.TXT"));
-        assert_eq!(path.directory(), Some("/DOCUMENTS/JUNE"));
-        assert_eq!(path.filename(), Some("SALES.TXT"));
-        assert_eq!(path.extension(), Some("TXT"));
-    }
+// None
 
-    #[test]
-    fn relative_path() {
-        let path_str = "DOCUMENTS/JUNE/SALES.TXT";
-        let path = Path::new(path_str).unwrap();
-        assert!(!path.is_absolute_path());
-        assert_eq!(path.drive_specifier(), None);
-        assert_eq!(path.drive_path(), Some("DOCUMENTS/JUNE/SALES.TXT"));
-        assert_eq!(path.directory(), Some("DOCUMENTS/JUNE"));
-        assert_eq!(path.filename(), Some("SALES.TXT"));
-        assert_eq!(path.extension(), Some("TXT"));
-    }
+// ============================================================================
+// Tests
+// ============================================================================
 
-    #[test]
-    fn full_dir() {
-        let path_str = "HD0:/DOCUMENTS/JUNE/";
-        let path = Path::new(path_str).unwrap();
-        assert!(path.is_absolute_path());
-        assert_eq!(path.drive_specifier(), Some("HD0"));
-        assert_eq!(path.drive_path(), Some("/DOCUMENTS/JUNE/"));
-        assert_eq!(path.directory(), Some("/DOCUMENTS/JUNE"));
-        assert_eq!(path.filename(), None);
-        assert_eq!(path.extension(), None);
-    }
+// None
 
-    #[test]
-    fn relative_dir() {
-        let path_str = "DOCUMENTS/";
-        let path = Path::new(path_str).unwrap();
-        assert!(!path.is_absolute_path());
-        assert_eq!(path.drive_specifier(), None);
-        assert_eq!(path.drive_path(), Some("DOCUMENTS/"));
-        assert_eq!(path.directory(), Some("DOCUMENTS"));
-        assert_eq!(path.filename(), None);
-        assert_eq!(path.extension(), None);
-    }
-}
+// ============================================================================
+// End of File
+// ============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,14 +109,19 @@ pub struct Api {
     pub stat: extern "C" fn(path: file::Path) -> Result<file::Stat>,
     /// Get information about an open file.
     pub fstat: extern "C" fn(fd: file::Handle) -> Result<file::Stat>,
-    /// Delete a file or directory.
+    /// Delete a file.
     ///
     /// # Limitations
     ///
     /// * You cannot delete a file if it is currently open.
+    pub deletefile: extern "C" fn(path: file::Path) -> Result<()>,
+    /// Delete a directory.
+    ///
+    /// # Limitations
+    ///
     /// * You cannot delete a root directory.
-    /// * You cannot delete a directory that has any files in it.
-    pub delete: extern "C" fn(path: file::Path) -> Result<()>,
+    /// * You cannot delete a directory that has any files or directories in it.
+    pub deletedir: extern "C" fn(path: file::Path) -> Result<()>,
     /// Change the current directory.
     ///
     /// Relative file paths (e.g. passed to `Api::open`) are taken to be relative to the current directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,14 +76,18 @@ pub struct Api {
     ///
     /// Some files do not support seeking and will produce an error.
     pub seek_set: extern "C" fn(fd: file::Handle, position: u64) -> Result<()>,
-    /// Move the file offset (for the given file handle) relative to the current position
+    /// Move the file offset (for the given file handle) relative to the current position.
+    ///
+    /// Returns the new file offset.
     ///
     /// Some files do not support seeking and will produce an error.
-    pub seek_cur: extern "C" fn(fd: file::Handle, offset: i64) -> Result<()>,
+    pub seek_cur: extern "C" fn(fd: file::Handle, offset: i64) -> Result<u64>,
     /// Move the file offset (for the given file handle) to the end of the file
     ///
+    /// Returns the new file offset.
+    ///
     /// Some files do not support seeking and will produce an error.
-    pub seek_end: extern "C" fn(fd: file::Handle) -> Result<()>,
+    pub seek_end: extern "C" fn(fd: file::Handle) -> Result<u64>,
     /// Rename a file.
     ///
     /// # Limitations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod dir;
 pub mod file;
+pub mod path;
 
 pub use neotron_ffi::{FfiBuffer, FfiByteSlice, FfiString};
 
@@ -47,7 +48,7 @@ pub struct Api {
     /// * You cannot open a file if it is currently open.
     /// * Paths must confirm to the rules for the filesystem for the given drive.
     /// * Relative paths are taken relative to the current directory (see `Api::chdir`).
-    pub open: extern "C" fn(path: file::Path, flags: file::Flags) -> Result<file::Handle>,
+    pub open: extern "C" fn(path: FfiString, flags: file::Flags) -> Result<file::Handle>,
     /// Close a previously opened file.
     ///
     /// Closing a file is important, as only this action will cause the
@@ -96,17 +97,17 @@ pub struct Api {
     /// * You cannot rename a file where the `old_path` and the `new_path` are
     /// not on the same drive.
     /// * Paths must confirm to the rules for the filesystem for the given drive.
-    pub rename: extern "C" fn(old_path: file::Path, new_path: file::Path) -> Result<()>,
+    pub rename: extern "C" fn(old_path: FfiString, new_path: FfiString) -> Result<()>,
     /// Perform a special I/O control operation.
     pub ioctl: extern "C" fn(fd: file::Handle, command: u64, value: u64) -> Result<u64>,
     /// Open a directory, given a path as a UTF-8 string.
-    pub opendir: extern "C" fn(path: file::Path) -> Result<dir::Handle>,
+    pub opendir: extern "C" fn(path: FfiString) -> Result<dir::Handle>,
     /// Close a previously opened directory.
     pub closedir: extern "C" fn(dir: dir::Handle) -> Result<()>,
     /// Read from an open directory
     pub readdir: extern "C" fn(dir: dir::Handle) -> Result<dir::Entry>,
     /// Get information about a file.
-    pub stat: extern "C" fn(path: file::Path) -> Result<file::Stat>,
+    pub stat: extern "C" fn(path: FfiString) -> Result<file::Stat>,
     /// Get information about an open file.
     pub fstat: extern "C" fn(fd: file::Handle) -> Result<file::Stat>,
     /// Delete a file.
@@ -114,21 +115,21 @@ pub struct Api {
     /// # Limitations
     ///
     /// * You cannot delete a file if it is currently open.
-    pub deletefile: extern "C" fn(path: file::Path) -> Result<()>,
+    pub deletefile: extern "C" fn(path: FfiString) -> Result<()>,
     /// Delete a directory.
     ///
     /// # Limitations
     ///
     /// * You cannot delete a root directory.
     /// * You cannot delete a directory that has any files or directories in it.
-    pub deletedir: extern "C" fn(path: file::Path) -> Result<()>,
+    pub deletedir: extern "C" fn(path: FfiString) -> Result<()>,
     /// Change the current directory.
     ///
     /// Relative file paths (e.g. passed to `Api::open`) are taken to be relative to the current directory.
     ///
     /// Unlike on MS-DOS, there is only one current directory for the whole
     /// system, not one per drive.
-    pub chdir: extern "C" fn(path: file::Path) -> Result<()>,
+    pub chdir: extern "C" fn(path: FfiString) -> Result<()>,
     /// Change the current directory to the given open directory.
     ///
     /// Unlike on MS-DOS, there is only one current directory for the whole
@@ -176,6 +177,18 @@ pub enum Error {
     /// The given path was invalid
     InvalidPath,
 }
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+// None
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+// None
 
 // ============================================================================
 // End of File

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,8 +157,8 @@ pub struct Api {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Error {
-    /// The given file path was not found
-    FileNotFound,
+    /// The given file/directory path was not found
+    NotFound,
     /// Tried to write to a read-only file
     FileReadOnly,
     /// Reached the end of the file
@@ -167,8 +167,8 @@ pub enum Error {
     Unimplemented,
     /// An invalid argument was given to the API
     InvalidArg,
-    /// A bad file handle was given to the API
-    BadFileHandle,
+    /// A bad handle was given to the API
+    BadHandle,
     /// An device-specific error occurred. Look at the BIOS source for more details.
     DeviceSpecific,
     /// The OS does not have enough memory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub struct Api {
     /// The current directory is stored as UTF-8 into the given buffer. The
     /// function returns the number of bytes written to the buffer, or an error.
     /// If the function did not return an error, the buffer can be assumed to
-    /// contain a valid file path.
+    /// contain a valid file path. That path will not be null terminated.
     pub pwd: extern "C" fn(path: FfiBuffer) -> Result<usize>,
     /// Allocate some memory.
     ///

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,279 @@
+//! Path related types.
+//!
+//! These aren't used in the API itself, but will be useful to code on both
+//! sides of the API, so they live here.
+
+// ============================================================================
+// Imports
+// ============================================================================
+
+// None
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// None
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// Represents a (borrowed) path to file.
+///
+/// Neotron OS uses the following format for file paths:
+///
+/// `<drive>:/[<directory>/]...<filename>.<extension>`
+///
+/// Unlike on MS-DOS, the `drive` specifier portion is not limited to a single
+/// ASCII letter and can be any UTF-8 string that does not contain `:` or `/`.
+///
+/// Typically drives will look like `DEV:` or `HD0:`, but that's not enforced
+/// here.
+///
+/// Paths are a sub-set of UTF-8 strings in this API, but be aware that not all
+/// filesystems support all Unicode characters. In particular FAT16 and FAT32
+/// volumes are likely to be limited to only `A-Z`, `a-z`, `0-9` and
+/// `$%-_@~\`!(){}^#&`. This API will expressly disallow UTF-8 codepoints below
+/// 32 (i.e. C0 control characters) to avoid confusion, but non-ASCII
+/// code-points are accepted.
+///
+/// Paths are case-preserving but file operations may not be case-sensitive
+/// (depending on the filesystem you are accessing). Paths may contain spaces
+/// (but your filesystem may not support that).
+///  
+/// Here are some examples of valid paths:
+///
+/// ```text
+/// # relative to the Current Directory
+/// Documents/2023/June/Sales in €.xls
+/// # a file on drive HD0
+/// HD0:/MYDOCU~1/SALES.TXT
+/// # a directory on drive SD0
+/// SD0:/MYDOCU~1/
+/// # a file on drive SD0, with no file extension
+/// SD0:/BOOTLDR
+/// ```
+///
+/// Files and Directories generally have distinct APIs, so a directory without a
+/// trailing `/` is likely to be accepted. A file path with a trailing `/` won't
+/// be accepted.
+pub struct Path<'a>(&'a str);
+
+impl<'a> Path<'a> {
+    /// The character that separates one directory name from another directory name.
+    pub const PATH_SEP: char = '/';
+
+    /// The character that separates drive specifiers from directories.
+    pub const DRIVE_SEP: char = ':';
+
+    /// Create a path from a string.
+    ///
+    /// If the given string is not a valid path, an `Err` is returned.
+    pub fn new(path_str: &'a str) -> Result<Path<'a>, crate::Error> {
+        // No empty paths in drive specifier
+        if path_str.is_empty() {
+            return Err(crate::Error::InvalidPath);
+        }
+
+        if let Some((drive_specifier, directory_path)) = path_str.split_once(Self::DRIVE_SEP) {
+            if drive_specifier.contains(Self::PATH_SEP) {
+                // No slashes in drive specifier
+                return Err(crate::Error::InvalidPath);
+            }
+            if directory_path.contains(Self::DRIVE_SEP) {
+                // No colons in directory path
+                return Err(crate::Error::InvalidPath);
+            }
+            if !directory_path.is_empty() && !directory_path.starts_with(Self::PATH_SEP) {
+                // No relative paths if drive is specified. An empty path is OK (it means "/")
+                return Err(crate::Error::InvalidPath);
+            }
+        } else if path_str.starts_with(Self::PATH_SEP) {
+            // No absolute paths if drive is not specified
+            return Err(crate::Error::InvalidPath);
+        }
+        for ch in path_str.chars() {
+            if ch.is_control() {
+                // No control characters allowed
+                return Err(crate::Error::InvalidPath);
+            }
+        }
+        Ok(Path(path_str))
+    }
+
+    /// Is this an absolute path?
+    ///
+    /// Absolute paths have drive specifiers. Relative paths do not.
+    pub fn is_absolute_path(&self) -> bool {
+        self.drive_specifier().is_some()
+    }
+
+    /// Get the drive specifier for this path.
+    ///
+    /// * A path like `DS0:/FOO/BAR.TXT` has a drive specifier of `DS0`.
+    /// * A path like `BAR.TXT` has no drive specifier.
+    pub fn drive_specifier(&self) -> Option<&str> {
+        if let Some((drive_specifier, _directory_path)) = self.0.split_once(Self::DRIVE_SEP) {
+            Some(drive_specifier)
+        } else {
+            None
+        }
+    }
+
+    /// Get the drive path portion.
+    ///
+    /// That is, everything after the directory specifier.
+    pub fn drive_path(&self) -> Option<&str> {
+        if let Some((_drive_specifier, drive_path)) = self.0.split_once(Self::DRIVE_SEP) {
+            if drive_path.is_empty() {
+                // Bare drives are assumed to be at the root
+                Some("/")
+            } else {
+                Some(drive_path)
+            }
+        } else {
+            Some(self.0)
+        }
+    }
+
+    /// Get the directory portion of this path.
+    ///
+    /// * A path like `DS0:/FOO/BAR.TXT` has a directory portion of `/FOO`.
+    /// * A path like `DS0:/FOO/BAR/` has a directory portion of `/FOO/BAR`.
+    /// * A path like `BAR.TXT` has no directory portion.
+    pub fn directory(&self) -> Option<&str> {
+        let Some(drive_path) = self.drive_path() else {
+            return None;
+        };
+        if let Some((directory, _filename)) = drive_path.rsplit_once(Self::PATH_SEP) {
+            if directory.is_empty() {
+                // Bare drives are assumed to be at the root
+                Some("/")
+            } else {
+                Some(directory)
+            }
+        } else {
+            Some(drive_path)
+        }
+    }
+
+    /// Get the filename portion of this path. This filename will include the file extension, if any.
+    ///
+    /// * A path like `DS0:/FOO/BAR.TXT` has a filename portion of `/BAR.TXT`.
+    /// * A path like `DS0:/FOO` has a filename portion of `/FOO`.
+    /// * A path like `DS0:/FOO/` has no filename portion (so it's important directories have a trailing `/`)
+    pub fn filename(&self) -> Option<&str> {
+        let Some(drive_path) = self.drive_path() else {
+            return None;
+        };
+        if let Some((_directory, filename)) = drive_path.rsplit_once(Self::PATH_SEP) {
+            if filename.is_empty() {
+                None
+            } else {
+                Some(filename)
+            }
+        } else {
+            Some(drive_path)
+        }
+    }
+
+    /// Get the filename extension portion of this path.
+    ///
+    /// A path like `DS0:/FOO/BAR.TXT` has a filename extension portion of `TXT`.
+    /// A path like `DS0:/FOO/BAR` has no filename extension portion.
+    pub fn extension(&self) -> Option<&str> {
+        let Some(filename) = self.filename() else {
+            return None;
+        };
+        if let Some((_basename, extension)) = filename.rsplit_once('.') {
+            Some(extension)
+        } else {
+            None
+        }
+    }
+
+    /// View this [`Path`] as a string-slice.
+    pub fn as_str(&self) -> &str {
+        self.0
+    }
+}
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+// None
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_path() {
+        let path_str = "HD0:/DOCUMENTS/JUNE/SALES.TXT";
+        let path = Path::new(path_str).unwrap();
+        assert!(path.is_absolute_path());
+        assert_eq!(path.drive_specifier(), Some("HD0"));
+        assert_eq!(path.drive_path(), Some("/DOCUMENTS/JUNE/SALES.TXT"));
+        assert_eq!(path.directory(), Some("/DOCUMENTS/JUNE"));
+        assert_eq!(path.filename(), Some("SALES.TXT"));
+        assert_eq!(path.extension(), Some("TXT"));
+    }
+
+    #[test]
+    fn bare_drive() {
+        let path_str = "HD0:";
+        let path = Path::new(path_str).unwrap();
+        assert!(path.is_absolute_path());
+        assert_eq!(path.drive_specifier(), Some("HD0"));
+        assert_eq!(path.drive_path(), Some("/"));
+        assert_eq!(path.directory(), Some("/"));
+        assert_eq!(path.filename(), None);
+        assert_eq!(path.extension(), None);
+    }
+
+    #[test]
+    fn relative_path() {
+        let path_str = "DOCUMENTS/JUNE/SALES.TXT";
+        let path = Path::new(path_str).unwrap();
+        assert!(!path.is_absolute_path());
+        assert_eq!(path.drive_specifier(), None);
+        assert_eq!(path.drive_path(), Some("DOCUMENTS/JUNE/SALES.TXT"));
+        assert_eq!(path.directory(), Some("DOCUMENTS/JUNE"));
+        assert_eq!(path.filename(), Some("SALES.TXT"));
+        assert_eq!(path.extension(), Some("TXT"));
+    }
+
+    #[test]
+    fn full_dir() {
+        let path_str = "HD0:/DOCUMENTS/JUNE/";
+        let path = Path::new(path_str).unwrap();
+        assert!(path.is_absolute_path());
+        assert_eq!(path.drive_specifier(), Some("HD0"));
+        assert_eq!(path.drive_path(), Some("/DOCUMENTS/JUNE/"));
+        assert_eq!(path.directory(), Some("/DOCUMENTS/JUNE"));
+        assert_eq!(path.filename(), None);
+        assert_eq!(path.extension(), None);
+    }
+
+    #[test]
+    fn relative_dir() {
+        let path_str = "DOCUMENTS/";
+        let path = Path::new(path_str).unwrap();
+        assert!(!path.is_absolute_path());
+        assert_eq!(path.drive_specifier(), None);
+        assert_eq!(path.drive_path(), Some("DOCUMENTS/"));
+        assert_eq!(path.directory(), Some("DOCUMENTS"));
+        assert_eq!(path.filename(), None);
+        assert_eq!(path.extension(), None);
+    }
+}
+
+// ============================================================================
+// End of File
+// ============================================================================


### PR DESCRIPTION
* Adds a return value to the two relative seek APIs, which you can see to know where you are in a file. 
* Changes the Path API so it's based on `&str`.
* Splits delete into two APIs.
* Makes file and dir handles copy/clone.

Closes #2 